### PR TITLE
Use `clientSecret` option in example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Here's an example of how to construct and configure the strategy:
 
     passport.use(new EveOnlineStrategy({
         clientID: EVEONLINE_CLIENT_ID,
-        secretKey: EVEONLINE_SECRET_KEY,
+        clientSecret: EVEONLINE_SECRET_KEY,
         callbackURL: "http://mysite.com/auth/eveonline/callback"
       },
       function(characterInformation, done) {


### PR DESCRIPTION
Using `secretKey` in my code wasn't working. After some digging in the source, I found `clientSecret` was needed by the underlying passport-oauth2 code.
